### PR TITLE
Add handler callbacks to API

### DIFF
--- a/API/IRichPresenceAPI.cs
+++ b/API/IRichPresenceAPI.cs
@@ -8,6 +8,7 @@ public interface IRichPresenceAPI
 {
 	public void SetRichPresence(string message, int imageKey);
 	public void SetRichPresence(string message, string imageKey);
+	public string GetRichPresence();
 	public void SetTriggerActivation(bool active);
 	public GameObject CreateTrigger(GameObject parent, string message, string imageKey);
 	public GameObject CreateTrigger(GameObject parent, Sector sector, string message, string imageKey);

--- a/API/IRichPresenceAPI.cs
+++ b/API/IRichPresenceAPI.cs
@@ -8,7 +8,6 @@ public interface IRichPresenceAPI
 {
 	public void SetRichPresence(string message, int imageKey);
 	public void SetRichPresence(string message, string imageKey);
-	public string GetRichPresence();
 	public void SetTriggerActivation(bool active);
 	public GameObject CreateTrigger(GameObject parent, string message, string imageKey);
 	public GameObject CreateTrigger(GameObject parent, Sector sector, string message, string imageKey);
@@ -21,4 +20,5 @@ public interface IRichPresenceAPI
 	public GameObject CreateTriggerVolume(GameObject parent, Vector3 localPosition, float radius, string message, string imageKey);
 	public GameObject CreateTriggerVolume(GameObject parent, Vector3 localPosition, float radius, string message, string imageKey, string fallback);
 	public void SetCurrentRootPresence(string message, string imageKey);
+	public void RegisterHandler(Action<string, string, string> handler);
 }

--- a/API/RichPresenceAPI.cs
+++ b/API/RichPresenceAPI.cs
@@ -14,6 +14,9 @@ public class RichPresenceAPI : IRichPresenceAPI
 	public void SetRichPresence(string message, string imageKey)
 		=> OWRichPresence.SetPresence(message, EnumUtils.Parse<ImageKey>(imageKey, true, ImageKey.sun));
 
+	public (string message, string imageKey) GetRichPresence()
+		=> OWRichPresence.GetPresence();
+
 	public void SetTriggerActivation(bool active)
 		=> OWRichPresence.TriggersActive = active;
 

--- a/API/RichPresenceAPI.cs
+++ b/API/RichPresenceAPI.cs
@@ -14,9 +14,6 @@ public class RichPresenceAPI : IRichPresenceAPI
 	public void SetRichPresence(string message, string imageKey)
 		=> OWRichPresence.SetPresence(message, EnumUtils.Parse<ImageKey>(imageKey, true, ImageKey.sun));
 
-	public (string message, string imageKey) GetRichPresence()
-		=> OWRichPresence.GetPresence();
-
 	public void SetTriggerActivation(bool active)
 		=> OWRichPresence.TriggersActive = active;
 
@@ -68,4 +65,7 @@ public class RichPresenceAPI : IRichPresenceAPI
 
 	public void SetCurrentRootPresence(string message, string imageKey)
 		=> OWRichPresence.Instance.SetRootPresence(message, EnumUtils.Parse<ImageKey>(imageKey, true, ImageKey.sun));
+
+	public void RegisterHandler(Action<string, string, string> handler)
+		=> OWRichPresence.RegisterHandler(handler);
 }

--- a/OWRichPresence.cs
+++ b/OWRichPresence.cs
@@ -379,11 +379,11 @@ namespace OWRichPresence
 		public static void SetPresence(string details, ImageKey imageKey) => SetPresence(MakePresence(details, imageKey));
 		public static void SetPresence(RichPresence richPresence)
 		{
-			Instance.client.SetPresence(richPresence);
 			foreach (var handler in Instance.handlers)
 			{
 				handler(richPresence.Details, richPresence.Assets.LargeImageKey, richPresence.Assets.LargeImageText);
 			}
+			Instance.client.SetPresence(richPresence);
 		}
 
 		public static void RegisterHandler(Action<string, string, string> handler)

--- a/OWRichPresence.cs
+++ b/OWRichPresence.cs
@@ -188,7 +188,7 @@ namespace OWRichPresence
 					SetRootPresence("Unknown", ImageKey.outerwilds);
 					break;
 			}
-			client.SetPresence(_presenceStack.Peek());
+			SetPresence(_presenceStack.Peek());
 		}
 
 		private static void AddObservatoryHemisphere()
@@ -376,7 +376,7 @@ namespace OWRichPresence
 			};
 		}
 
-		public static void SetPresence(string details, ImageKey imageKey) => Instance.client.SetPresence(MakePresence(details, imageKey));
+		public static void SetPresence(string details, ImageKey imageKey) => SetPresence(MakePresence(details, imageKey));
 		public static void SetPresence(RichPresence richPresence)
 		{
 			Instance.client.SetPresence(richPresence);

--- a/OWRichPresence.cs
+++ b/OWRichPresence.cs
@@ -4,6 +4,8 @@ using DiscordRPC;
 using DiscordRPC.Unity;
 using UnityEngine;
 using OWRichPresence.API;
+using System;
+using System.Collections.Generic;
 
 namespace OWRichPresence
 {
@@ -16,6 +18,8 @@ namespace OWRichPresence
 		public ListStack<RichPresence> _presenceStack = new();
 		public RichPresence _shipPresence;
 		public RichPresence _giantsDeepPresence;
+
+		public readonly List<Action<string, string, string>> handlers = new();
 
 #if DEBUG
 		private static bool debug = true;
@@ -373,7 +377,18 @@ namespace OWRichPresence
 		}
 
 		public static void SetPresence(string details, ImageKey imageKey) => Instance.client.SetPresence(MakePresence(details, imageKey));
-		public static void SetPresence(RichPresence richPresence) => Instance.client.SetPresence(richPresence);
-		public static string GetPresence() => Instance._presenceStack.Peek().Details;
+		public static void SetPresence(RichPresence richPresence)
+		{
+			Instance.client.SetPresence(richPresence);
+			foreach (var handler in Instance.handlers)
+			{
+				handler(richPresence.Details, richPresence.Assets.LargeImageKey, richPresence.Assets.LargeImageText);
+			}
+		}
+
+		public static void RegisterHandler(Action<string, string, string> handler)
+		{
+			Instance.handlers.Add(handler);
+		}
 	}
 }

--- a/OWRichPresence.cs
+++ b/OWRichPresence.cs
@@ -374,5 +374,6 @@ namespace OWRichPresence
 
 		public static void SetPresence(string details, ImageKey imageKey) => Instance.client.SetPresence(MakePresence(details, imageKey));
 		public static void SetPresence(RichPresence richPresence) => Instance.client.SetPresence(richPresence);
+		public static string GetPresence() => Instance._presenceStack.Peek().Details;
 	}
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "author": "MegaPiggy",
   "name": "Discord Rich Presence",
   "uniqueName": "MegaPiggy.OWRichPresence",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "owmlVersion": "2.9.8",
   "priorityLoad": true
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "author": "MegaPiggy",
   "name": "Discord Rich Presence",
   "uniqueName": "MegaPiggy.OWRichPresence",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "owmlVersion": "2.9.8",
   "priorityLoad": true
 }


### PR DESCRIPTION
I've been working on [a mod](https://github.com/qguv/OuterWildsAtHome) to push the current planet to Home Assistant to control custom lights in my game room. To do this, I've leveraged the planet detection features of this mod by [adding an API method](https://github.com/qguv/OWRichPresence/blob/77b62fc94b8ca0e39063f3b2dfa8738aab5d6cf3/API/IRichPresenceAPI.cs#L23) to register a callback when the state is changed. This way, consumers can [ask for updates](https://github.com/qguv/OuterWildsAtHome/blob/3adcfc5b8394490b2559d4819194d076fb4d93f5/OuterWildsAtHome.cs#L25-L26) so they can [update services other than Discord](https://github.com/qguv/OuterWildsAtHome/blob/3adcfc5b8394490b2559d4819194d076fb4d93f5/OuterWildsAtHome.cs#L46).

Would you be comfortable merging this small change into OWRichPresence? Then I can publish my mod :)

Thanks for the consideration~